### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: "0 0 * * 0"
 
+permissions:
+  contents: write
+
 jobs:
   update-gradle-wrapper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/termux-monet/security/code-scanning/6](https://github.com/FlutterGenerator/termux-monet/security/code-scanning/6)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will explicitly define the permissions required for the workflow. Based on the steps in the workflow, the `contents: read` permission is sufficient for the `actions/checkout` step, and the `gradle-update/update-gradle-wrapper-action` step likely requires `contents: write` to update the Gradle wrapper files. Therefore, the `permissions` block should include `contents: write`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
