### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trigger_library_builds_on_jitpack.yml
+++ b/.github/workflows/trigger_library_builds_on_jitpack.yml
@@ -3,6 +3,9 @@ name: Trigger Termux Library Builds on Jitpack
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/termux-monet/security/code-scanning/4](https://github.com/FlutterGenerator/termux-monet/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the workflow does not interact with repository contents or pull requests, we will set `contents: read` as the only permission. This ensures the workflow has the least privilege necessary to execute its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
