### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release_build.yml
+++ b/.github/workflows/release_build.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/termux-monet/security/code-scanning/3](https://github.com/FlutterGenerator/termux-monet/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the tasks in the workflow (e.g., cloning the repository, setting up Java, building APKs, and uploading artifacts), the workflow likely only needs `contents: read` permission. This ensures that the workflow can read the repository contents but cannot make any changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
