### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,4 +1,6 @@
 name: "Validate Gradle Wrapper"
+permissions:
+  contents: read
 
 on:
   workflow_dispatch


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/termux-monet/security/code-scanning/1](https://github.com/FlutterGenerator/termux-monet/security/code-scanning/1)

To fix the problem, we should explicitly set the `permissions` key in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow only checks out code and validates the Gradle wrapper, it only needs read access to repository contents. The best way to do this is to add a `permissions` block at the top level of the workflow file (after the `name` and before `on`), setting `contents: read`. This will apply to all jobs in the workflow unless overridden. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
